### PR TITLE
Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "container-interop/container-interop": "^1.1",
         "laminas/laminas-coding-standard": "~1.0.0",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5 || ^8.0.0 || ^9.3"
+        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5 || ^8.0.0 || ^9.3",
+        "psalm/plugin-phpunit": "^0.13.0",
+        "vimeo/psalm": "^4.2"
     },
     "autoload": {
         "psr-4": {
@@ -56,6 +58,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
     "require-dev": {
         "container-interop/container-interop": "^1.1",
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5 || ^8.0.0 || ^9.3",
+        "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "^0.13.0",
         "vimeo/psalm": "^4.2"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.2.1@ea9cb72143b77e7520c52fa37290bd8d8bc88fd9">
+  <file src="config/module.config.php">
+    <UndefinedClass occurrences="6">
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigWriter</code>
+      <code>ConfigWriter</code>
+      <code>\ZF\Configuration\ConfigResourceFactory</code>
+      <code>\ZF\Configuration\ConfigWriter</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/ConfigResource.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! is_array($array)</code>
+      <code>is_array($patchValues)</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="4">
+      <code>createNestedKeyValuePair</code>
+      <code>deleteByKey</code>
+      <code>extractAndSet</code>
+      <code>invalidateCache</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$array[$key]</code>
+      <code>$config[$key]</code>
+      <code>$key</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$key</code>
+      <code>$targetKey</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayOffset occurrences="7">
+      <code>$array[$key]</code>
+      <code>$array[$key]</code>
+      <code>$array[$key]</code>
+      <code>$config[$key]</code>
+      <code>$config[$key]</code>
+      <code>$config[$key]</code>
+      <code>$config[$key]</code>
+    </MixedArrayOffset>
+    <MixedArrayTypeCoercion occurrences="2">
+      <code>$array[$key]</code>
+      <code>$config[$key]</code>
+    </MixedArrayTypeCoercion>
+    <MixedAssignment occurrences="10">
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config[$key]</code>
+      <code>$flattened[$targetKey]</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$localConfig</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Factory/ConfigResourceFactory.php">
+    <MissingPropertyType occurrences="1">
+      <code>$defaultConfigFile</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get(ConfigWriter::class)</code>
+      <code>ConfigWriter::class</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="2">
+      <code>array</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="3">
+      <code>$config['api-tools-configuration']['config_file']</code>
+      <code>$container-&gt;get('config')</code>
+      <code>$this-&gt;defaultConfigFile</code>
+    </MixedReturnStatement>
+    <UndefinedClass occurrences="1">
+      <code>ConfigWriter</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Factory/ConfigWriterFactory.php">
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-configuration']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Factory/ModuleUtilsFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get('ModuleManager')</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Factory/ResourceFactoryFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$container-&gt;get(ConfigWriter::class)</code>
+      <code>$container-&gt;get(ModuleUtils::class)</code>
+      <code>ConfigWriter::class</code>
+    </MixedArgument>
+    <UndefinedClass occurrences="1">
+      <code>ConfigWriter</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Module.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>include __DIR__ . '/../config/module.config.php'</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/ModuleUtils.php">
+    <MissingReturnType occurrences="2">
+      <code>deriveModuleData</code>
+      <code>validateModule</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$module</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$module</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>string</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$this-&gt;moduleData[$moduleName]['config']</code>
+      <code>$this-&gt;moduleData[$moduleName]['path']</code>
+    </MixedReturnStatement>
+    <NullableReturnStatement occurrences="2">
+      <code>$this-&gt;moduleData[$moduleName]['config']</code>
+      <code>$this-&gt;moduleData[$moduleName]['path']</code>
+    </NullableReturnStatement>
+  </file>
+  <file src="src/ResourceFactory.php">
+    <MissingParamType occurrences="1">
+      <code>$filePath</code>
+    </MissingParamType>
+    <MixedArgument occurrences="2">
+      <code>$config</code>
+      <code>$filePath</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+    <UnresolvableInclude occurrences="1">
+      <code>include $moduleConfigPath</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/ConfigResourceFactoryTest.php">
+    <MissingReturnType occurrences="4">
+      <code>testCustomConfigFileIsSet</code>
+      <code>testCustomConfigurationIsPassToConfigResource</code>
+      <code>testDefaultAttributesValues</code>
+      <code>testReturnsInstanceOfConfigResource</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="6">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="10">
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="1">
+      <code>ConfigWriter</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/ConfigResourceTest.php">
+    <MissingParamType occurrences="6">
+      <code>$array1</code>
+      <code>$array2</code>
+      <code>$expected</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$file</code>
+      <code>$writer</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="14">
+      <code>arrayIntersectAssocRecursive</code>
+      <code>deleteKeyPairs</code>
+      <code>removeScaffold</code>
+      <code>replaceKeyPairs</code>
+      <code>testCreateNestedKeyValuePairExtractsDotSeparatedKeysAndCreatesNestedStructure</code>
+      <code>testDeleteKey</code>
+      <code>testDeleteNestedKeyShouldAssignArrayToParent</code>
+      <code>testDeleteNonexistentKeyShouldDoNothing</code>
+      <code>testFetchFlattensComposedConfiguration</code>
+      <code>testFetchWithTreeFlagSetToTrueReturnsConfigurationUnmodified</code>
+      <code>testPatchListUpdatesFileWithMergedConfig</code>
+      <code>testPatchWithTreeFlagSetToTruePerformsArrayMergeAndReturnsConfig</code>
+      <code>testReplaceKey</code>
+      <code>testTraverseArrayFlattensToDotSeparatedKeyValuePairs</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="21">
+      <code>$key</code>
+      <code>$key</code>
+      <code>$patchValues['foo']</code>
+      <code>$patchValues['foo']['bar']</code>
+      <code>$patchValues['foo']['bar']</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;file</code>
+      <code>$this-&gt;writer</code>
+      <code>$this-&gt;writer</code>
+      <code>$this-&gt;writer</code>
+      <code>$this-&gt;writer</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="6">
+      <code>$patchValues['foo']['bar']</code>
+      <code>$patchValues['foo']['bar']</code>
+      <code>$patchValues['foo']['bar']</code>
+      <code>$patchValues['foo']['bar']</code>
+      <code>$test['sub']</code>
+      <code>$test['sub']['sub2']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="7">
+      <code>$intersection</code>
+      <code>$return[$key]</code>
+      <code>$test</code>
+      <code>$test</code>
+      <code>$value</code>
+      <code>$written</code>
+      <code>$written</code>
+    </MixedAssignment>
+    <NoInterfaceProperties occurrences="2">
+      <code>$this-&gt;writer-&gt;writtenConfig</code>
+      <code>$this-&gt;writer-&gt;writtenConfig</code>
+    </NoInterfaceProperties>
+    <UnresolvableInclude occurrences="6">
+      <code>include $this-&gt;file</code>
+      <code>include $this-&gt;file</code>
+      <code>include $this-&gt;file</code>
+      <code>include $this-&gt;file</code>
+      <code>include $this-&gt;file</code>
+      <code>include $this-&gt;file</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/ConfigWriterFactoryTest.php">
+    <UndefinedTrait occurrences="1">
+      <code>ProphecyTrait</code>
+    </UndefinedTrait>
+  </file>
+  <file src="test/ResourceFactoryTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$resourceFactory</code>
+      <code>$testWriter</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>testCreateConfigResource</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>createConfigResource</code>
+    </MixedMethodCall>
+    <MixedPropertyFetch occurrences="2">
+      <code>$this-&gt;testWriter-&gt;writtenConfig</code>
+      <code>$this-&gt;testWriter-&gt;writtenFilename</code>
+    </MixedPropertyFetch>
+    <TooManyArguments occurrences="1">
+      <code>getMockBuilder</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/TestAsset/ConfigWriter.php">
+    <MissingPropertyType occurrences="2">
+      <code>$writtenConfig</code>
+      <code>$writtenFilename</code>
+    </MissingPropertyType>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="config"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,12 +4,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="config"/>
         <directory name="src"/>
         <directory name="test"/>
         <ignoreFiles>
+            <directory name="test/TestAsset"/>
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>

--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -283,6 +283,7 @@ class ConfigResource
      * @param string $key
      * @param mixed $value
      * @throws Exception\InvalidArgumentException
+     * @return void
      */
     public function createNestedKeyValuePair(&$patchValues, $key, $value)
     {
@@ -304,7 +305,7 @@ class ConfigResource
      * @param string $value
      * @param array $array
      */
-    protected function extractAndSet(array $keys, $value, &$array)
+    protected function extractAndSet(array $keys, $value, &$array): void
     {
         $key = array_shift($keys);
         if ($keys) {
@@ -321,10 +322,10 @@ class ConfigResource
     /**
      * Delete a nested key/value pair in an array
      *
-     * @param  array $array
-     * @param  array $keys
+     * @param array $array
+     * @param array $keys
      */
-    protected function deleteByKey(&$array, array $keys)
+    protected function deleteByKey(&$array, array $keys): void
     {
         $key = array_shift($keys);
         if (! is_array($array) || ! array_key_exists($key, $array)) {
@@ -341,9 +342,9 @@ class ConfigResource
     /**
      * Invalidate the opcache for a given file
      *
-     * @param  string $filename
+     * @param string $filename
      */
-    protected function invalidateCache($filename)
+    protected function invalidateCache($filename): void
     {
         if (! $this->opcacheEnabled) {
             return;

--- a/src/ModuleUtils.php
+++ b/src/ModuleUtils.php
@@ -76,10 +76,9 @@ class ModuleUtils
     /**
      * Validate that the module actually exists
      *
-     * @param  string $moduleName
      * @throws Exception\InvalidArgumentException if the module does not exist
      */
-    protected function validateModule($moduleName)
+    protected function validateModule(string $moduleName): void
     {
         if (! array_key_exists($moduleName, $this->modules)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -91,10 +90,8 @@ class ModuleUtils
 
     /**
      * Derive all module data from module name provided
-     *
-     * @param  string $moduleName
      */
-    protected function deriveModuleData($moduleName)
+    protected function deriveModuleData(string $moduleName): void
     {
         $configPath = $this->deriveModuleConfig($moduleName);
         $modulePath = dirname(dirname($configPath));
@@ -107,11 +104,9 @@ class ModuleUtils
     /**
      * Determines the location of the module configuration file
      *
-     * @param  string $moduleName
-     * @return string
      * @throws Exception\RuntimeException if unable to find the configuration file
      */
-    protected function deriveModuleConfig($moduleName)
+    protected function deriveModuleConfig(string $moduleName): string
     {
         $moduleClassPath = $this->getModuleClassPath($moduleName);
         $configPath      = $this->recurseTree($moduleClassPath);
@@ -128,11 +123,8 @@ class ModuleUtils
 
     /**
      * Derives the module class's filesystem location
-     *
-     * @param  string $moduleName
-     * @return string
      */
-    protected function getModuleClassPath($moduleName)
+    protected function getModuleClassPath(string $moduleName): string
     {
         $module   = $this->modules[$moduleName];
         $r        = new ReflectionObject($module);
@@ -143,10 +135,9 @@ class ModuleUtils
     /**
      * Recurse upwards through a tree to find the module configuration file
      *
-     * @param  string $path
      * @return false|string
      */
-    protected function recurseTree($path)
+    protected function recurseTree(string $path)
     {
         if (! is_dir($path)) {
             return false;
@@ -169,11 +160,8 @@ class ModuleUtils
 
     /**
      * Normalize the module name
-     *
-     * @param  string $moduleName
-     * @return string
      */
-    protected function normalizeModuleName($moduleName)
+    protected function normalizeModuleName(string $moduleName): string
     {
         return str_replace(['.', '/'], '\\', $moduleName);
     }

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -53,13 +53,15 @@ class ResourceFactory
         $moduleConfigPath = $this->modules->getModuleConfigPath($moduleName);
         $config           = include $moduleConfigPath;
 
+        assert(is_array($config));
+
         $this->resources[$moduleName] = new ConfigResource($config, $moduleConfigPath, $this->writer);
         return $this->resources[$moduleName];
     }
 
     /**
      * @param array $config
-     * @param $filePath
+     * @param string $filePath
      * @return ConfigResource
      */
     public function createConfigResource(array $config, $filePath)

--- a/test/ConfigResourceFactoryTest.php
+++ b/test/ConfigResourceFactoryTest.php
@@ -46,9 +46,9 @@ class ConfigResourceFactoryTest extends TestCase
 
     public function testReturnsInstanceOfConfigResource(): void
     {
-        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(false);
+        $this->container->method('has')->with('config')->willReturn(false);
         $this->container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with(self::WRITER_SERVICE)
             ->willReturn($this->writer);
@@ -61,9 +61,9 @@ class ConfigResourceFactoryTest extends TestCase
 
     public function testDefaultAttributesValues(): void
     {
-        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(false);
+        $this->container->method('has')->with('config')->willReturn(false);
         $this->container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with(self::WRITER_SERVICE)
             ->willReturn($this->writer);
@@ -88,8 +88,8 @@ class ConfigResourceFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects($this->once())->method('has')->with('config')->willReturn(true);
-        $this->container->expects($this->atLeastOnce())->method('get')->will($this->returnValueMap([
+        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('get')->will(self::returnValueMap([
             ['config', $config],
             [self::WRITER_SERVICE, $this->writer],
         ]));
@@ -114,8 +114,8 @@ class ConfigResourceFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(true);
-        $this->container->expects($this->atLeastOnce())->method('get')->will($this->returnValueMap([
+        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('get')->will(self::returnValueMap([
             ['config', $config],
             [self::WRITER_SERVICE, $this->writer],
         ]));

--- a/test/ConfigWriterFactoryTest.php
+++ b/test/ConfigWriterFactoryTest.php
@@ -11,16 +11,14 @@ namespace LaminasTest\ApiTools\Configuration;
 use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\Configuration\Factory\ConfigWriterFactory;
 use Laminas\Config\Writer\PhpArray;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PHPUnit\ProphecyTrait;
-use Prophecy\Prophecy\ProphecyInterface;
 
 class ConfigWriterFactoryTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ContainerInterface|ProphecyInterface
+     * @var ContainerInterface|MockObject
+     * @psalm-var ContainerInterface&MockObject
      */
     private $container;
 
@@ -31,33 +29,33 @@ class ConfigWriterFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
         $this->factory = new ConfigWriterFactory();
     }
 
-    public function testReturnsInstanceOfPhpArrayWriter()
+    public function testReturnsInstanceOfPhpArrayWriter(): void
     {
         $factory = $this->factory;
-        $configWriter = $factory($this->container->reveal());
+        $configWriter = $factory($this->container);
 
         $this->assertInstanceOf(PhpArray::class, $configWriter);
     }
 
-    public function testDefaultFlagsValues()
+    public function testDefaultFlagsValues(): void
     {
         $factory = $this->factory;
 
         /** @var PhpArray $configWriter */
-        $configWriter = $factory($this->container->reveal());
+        $configWriter = $factory($this->container);
 
         $this->assertClassHasAttribute('useBracketArraySyntax', get_class($configWriter));
         $this->assertFalse($configWriter->getUseClassNameScalars());
     }
 
-    public function testEnableShortArrayFlagIsSet()
+    public function testEnableShortArrayFlagIsSet(): void
     {
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn([
+        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(true);
+        $this->container->expects($this->atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'enable_short_array' => true,
             ],
@@ -66,15 +64,15 @@ class ConfigWriterFactoryTest extends TestCase
         $factory = $this->factory;
 
         /** @var PhpArray $configWriter */
-        $configWriter = $factory($this->container->reveal());
+        $configWriter = $factory($this->container);
 
         $this->assertClassHasAttribute('useBracketArraySyntax', get_class($configWriter));
     }
 
-    public function testClassNameScalarsFlagIsSet()
+    public function testClassNameScalarsFlagIsSet(): void
     {
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn([
+        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(true);
+        $this->container->expects($this->atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'class_name_scalars' => true,
             ],
@@ -83,7 +81,7 @@ class ConfigWriterFactoryTest extends TestCase
         $factory = $this->factory;
 
         /** @var PhpArray $configWriter */
-        $configWriter = $factory($this->container->reveal());
+        $configWriter = $factory($this->container);
 
         $this->assertTrue($configWriter->getUseClassNameScalars());
     }

--- a/test/ConfigWriterFactoryTest.php
+++ b/test/ConfigWriterFactoryTest.php
@@ -54,8 +54,8 @@ class ConfigWriterFactoryTest extends TestCase
 
     public function testEnableShortArrayFlagIsSet(): void
     {
-        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(true);
-        $this->container->expects($this->atLeastOnce())->method('get')->with('config')->willReturn([
+        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'enable_short_array' => true,
             ],
@@ -71,8 +71,8 @@ class ConfigWriterFactoryTest extends TestCase
 
     public function testClassNameScalarsFlagIsSet(): void
     {
-        $this->container->expects($this->atLeastOnce())->method('has')->with('config')->willReturn(true);
-        $this->container->expects($this->atLeastOnce())->method('get')->with('config')->willReturn([
+        $this->container->method('has')->with('config')->willReturn(true);
+        $this->container->expects(self::atLeastOnce())->method('get')->with('config')->willReturn([
             'api-tools-configuration' => [
                 'class_name_scalars' => true,
             ],

--- a/test/ResourceFactoryTest.php
+++ b/test/ResourceFactoryTest.php
@@ -15,20 +15,23 @@ use PHPUnit\Framework\TestCase;
 
 class ResourceFactoryTest extends TestCase
 {
-    protected $testWriter = null;
-    protected $resourceFactory = null;
+    /** @var TestAsset\ConfigWriter */
+    protected $testWriter;
+
+    /** @var ResourceFactory */
+    protected $resourceFactory;
 
     protected function setUp(): void
     {
         $this->resourceFactory = new ResourceFactory(
-            $this->getMockBuilder(ModuleUtils::class, [], [], '', false)
+            $this->getMockBuilder(ModuleUtils::class)
                 ->disableOriginalConstructor()
                 ->getMock(),
             $this->testWriter = new TestAsset\ConfigWriter()
         );
     }
 
-    public function testCreateConfigResource()
+    public function testCreateConfigResource(): void
     {
         $resource = $this->resourceFactory->createConfigResource(['foo' => 'bar'], '/path/to/file.php');
         $this->assertInstanceOf(ConfigResource::class, $resource);

--- a/test/ResourceFactoryTest.php
+++ b/test/ResourceFactoryTest.php
@@ -24,9 +24,7 @@ class ResourceFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->resourceFactory = new ResourceFactory(
-            $this->getMockBuilder(ModuleUtils::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            $this->createMock(ModuleUtils::class),
             $this->testWriter = new TestAsset\ConfigWriter()
         );
     }


### PR DESCRIPTION
Adds Psalm integration to the CI workflow:

- Adds a `psalm.xml.dist` configuration file and `psalm-baseline.xml`
- Requires vimeo/psalm and psalm/plugin-phpunit as dev dependencies
- Removes phpspec/prophecy as a dev dependency
- Bumps PHPUnit version to 9.3 as minimum
- Adds static-analysis script
- Updates Travis config to run static analysis on test coverage targets
- Performs a number of changes suggested by Psalm where they were low-hanging fruit

Fixes #7
