### PR TITLE
Fix for missing ConfigWriter class and usage of ConfigResourceFactory instead of ResourceFactory in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ There are no events or listeners.
 
 `Laminas\ApiTools\Configuration\ConfigWriter` is by default an instance of `Laminas\Config\Writer\PhpArray`.  This
 service serves the purpose of providing the necessary dependencies for `ConfigResource` and
-`ConfigResourceFactory`.
+`ResourceFactory`.
+
+Deprecated in favour of `Laminas\Config\Writer\WriterInterface`.
 
 #### Laminas\ApiTools\Configuration\ConfigResource
 
@@ -107,9 +109,9 @@ service serves the purpose of providing the necessary dependencies for `ConfigRe
 methods such as `patch()` and `replace()`.  The service returned by the service manager is bound to
 the file specified in the `config_file` key.
 
-#### Laminas\ApiTools\Configuration\ConfigResourceFactory
+#### Laminas\ApiTools\Configuration\ResourceFactory
 
-`Laminas\ApiTools\Configuration\ConfigResourceFactory` is a factory service that provides consumers with the
+`Laminas\ApiTools\Configuration\ResourceFactory` is a factory service that provides consumers with the
 ability to create `Laminas\ApiTools\Configuration\ConfigResource` objects, with dependencies injected for specific
 config files (not the one listed in the `module.config.php`.
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,6 +6,8 @@
 
 namespace Laminas\ApiTools\Configuration;
 
+use Laminas\Config\Writer\WriterInterface;
+
 return [
     'api-tools-configuration' => [
         'config_file' => 'config/autoload/development.php',
@@ -18,18 +20,21 @@ return [
         // 'class_name_scalars' => true,
     ],
     'service_manager'         => [
-        // Legacy Zend Framework aliases
         'aliases'   => [
-            \ZF\Configuration\ConfigResource::class        => ConfigResource::class,
-            \ZF\Configuration\ConfigResourceFactory::class => ConfigResourceFactory::class,
-            \ZF\Configuration\ConfigWriter::class          => ConfigWriter::class,
-            \ZF\Configuration\ModuleUtils::class           => ModuleUtils::class,
+            // Legacy Zend Framework aliases
+            \ZF\Configuration\ConfigResource::class  => ConfigResource::class,
+            \ZF\Configuration\ResourceFactory::class => ResourceFactory::class,
+            \ZF\Configuration\ConfigWriter::class    => ConfigWriter::class,
+            \ZF\Configuration\ModuleUtils::class     => ModuleUtils::class,
+
+            // Alias for the stub ConfigWriter class
+            ConfigWriter::class => WriterInterface::class,
         ],
         'factories' => [
-            ConfigResource::class        => Factory\ConfigResourceFactory::class,
-            ConfigResourceFactory::class => Factory\ResourceFactoryFactory::class,
-            ConfigWriter::class          => Factory\ConfigWriterFactory::class,
-            ModuleUtils::class           => Factory\ModuleUtilsFactory::class,
+            ConfigResource::class  => Factory\ConfigResourceFactory::class,
+            ResourceFactory::class => Factory\ResourceFactoryFactory::class,
+            WriterInterface::class => Factory\ConfigWriterFactory::class,
+            ModuleUtils::class     => Factory\ModuleUtilsFactory::class,
         ],
     ],
 ];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,7 +6,6 @@
 
 namespace Laminas\ApiTools\Configuration;
 
-use Laminas\ApiTools\Configuration\Factory\ConfigResourceFactory;
 use Laminas\Config\Writer\WriterInterface;
 
 return [
@@ -30,12 +29,13 @@ return [
             \ZF\Configuration\ModuleUtils::class           => ModuleUtils::class,
 
             // Alias for the stub ConfigWriter class
-            // TODO Delete both of these in the next major release
-            ConfigWriter::class          => WriterInterface::class,
-            ConfigResourceFactory::class => ResourceFactory::class,
+            // TODO Delete these in the next major release
+            ConfigWriter::class                  => WriterInterface::class,
+            Factory\ConfigResourceFactory::class => ResourceFactory::class,
+            ConfigResourceFactory::class         => ResourceFactory::class,
         ],
         'factories' => [
-            ConfigResource::class  => ConfigResourceFactory::class,
+            ConfigResource::class  => Factory\ConfigResourceFactory::class,
             ResourceFactory::class => Factory\ResourceFactoryFactory::class,
             WriterInterface::class => Factory\ConfigWriterFactory::class,
             ModuleUtils::class     => Factory\ModuleUtilsFactory::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,6 +6,7 @@
 
 namespace Laminas\ApiTools\Configuration;
 
+use Laminas\ApiTools\Configuration\Factory\ConfigResourceFactory;
 use Laminas\Config\Writer\WriterInterface;
 
 return [
@@ -22,16 +23,19 @@ return [
     'service_manager'         => [
         'aliases'   => [
             // Legacy Zend Framework aliases
-            \ZF\Configuration\ConfigResource::class  => ConfigResource::class,
-            \ZF\Configuration\ResourceFactory::class => ResourceFactory::class,
-            \ZF\Configuration\ConfigWriter::class    => ConfigWriter::class,
-            \ZF\Configuration\ModuleUtils::class     => ModuleUtils::class,
+            \ZF\Configuration\ConfigResource::class        => ConfigResource::class,
+            \ZF\Configuration\ConfigResourceFactory::class => ResourceFactory::class,
+            \ZF\Configuration\ResourceFactory::class       => ResourceFactory::class,
+            \ZF\Configuration\ConfigWriter::class          => ConfigWriter::class,
+            \ZF\Configuration\ModuleUtils::class           => ModuleUtils::class,
 
             // Alias for the stub ConfigWriter class
-            ConfigWriter::class => WriterInterface::class,
+            // TODO Delete both of these in the next major release
+            ConfigWriter::class          => WriterInterface::class,
+            ConfigResourceFactory::class => ResourceFactory::class,
         ],
         'factories' => [
-            ConfigResource::class  => Factory\ConfigResourceFactory::class,
+            ConfigResource::class  => ConfigResourceFactory::class,
             ResourceFactory::class => Factory\ResourceFactoryFactory::class,
             WriterInterface::class => Factory\ConfigWriterFactory::class,
             ModuleUtils::class     => Factory\ModuleUtilsFactory::class,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,8 +5,9 @@
       <code>\ZF\Configuration\ResourceFactory</code>
       <code>\ZF\Configuration\ConfigWriter</code>
     </UndefinedClass>
-    <DeprecatedClass occurrences="2">
+    <DeprecatedClass occurrences="3">
       <code>ConfigWriter::class</code>
+      <code>ConfigResourceFactory::class</code>
     </DeprecatedClass>
   </file>
   <file src="src/ConfigResource.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2,13 +2,12 @@
 <files psalm-version="4.2.1@ea9cb72143b77e7520c52fa37290bd8d8bc88fd9">
   <file src="config/module.config.php">
     <UndefinedClass occurrences="6">
-      <code>ConfigResourceFactory</code>
-      <code>ConfigResourceFactory</code>
-      <code>ConfigWriter</code>
-      <code>ConfigWriter</code>
-      <code>\ZF\Configuration\ConfigResourceFactory</code>
+      <code>\ZF\Configuration\ResourceFactory</code>
       <code>\ZF\Configuration\ConfigWriter</code>
     </UndefinedClass>
+    <DeprecatedClass occurrences="2">
+      <code>ConfigWriter::class</code>
+    </DeprecatedClass>
   </file>
   <file src="src/ConfigResource.php">
     <DocblockTypeContradiction occurrences="2">
@@ -58,6 +57,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Factory/ConfigResourceFactory.php">
+    <DeprecatedClass occurrences="1">
+      <code>ConfigWriter::class</code>
+    </DeprecatedClass>
     <MissingPropertyType occurrences="1">
       <code>$defaultConfigFile</code>
     </MissingPropertyType>
@@ -92,6 +94,9 @@
     </MixedArgument>
   </file>
   <file src="src/Factory/ResourceFactoryFactory.php">
+    <DeprecatedClass occurrences="1">
+      <code>ConfigWriter::class</code>
+    </DeprecatedClass>
     <MixedArgument occurrences="3">
       <code>$container-&gt;get(ConfigWriter::class)</code>
       <code>$container-&gt;get(ModuleUtils::class)</code>
@@ -149,6 +154,9 @@
     </UnresolvableInclude>
   </file>
   <file src="test/ConfigResourceFactoryTest.php">
+    <DeprecatedClass occurrences="1">
+      <code>ConfigWriter::class</code>
+    </DeprecatedClass>
     <MissingReturnType occurrences="4">
       <code>testCustomConfigFileIsSet</code>
       <code>testCustomConfigurationIsPassToConfigResource</code>

--- a/src/ConfigResourceFactory.php
+++ b/src/ConfigResourceFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laminas\ApiTools\Configuration;
+
+/**
+ * Several Laminas API Tools libraries refer to the
+ * Laminas\ApiTools\Configuration\ConfigResourceFactory class which doesn't
+ * exist. This class is a stub to prevent BC Break change.
+ *
+ * @deprecated Use Laminas\ApiTools\Configuration\ResourceFactory instead.
+ */
+class ConfigResourceFactory extends ResourceFactory
+{
+}

--- a/src/ConfigWriter.php
+++ b/src/ConfigWriter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laminas\ApiTools\Configuration;
+
+use Laminas\Config\Writer\PhpArray;
+
+/**
+ * Several Laminas API Tools libraries refer to the
+ * Laminas\ApiTools\Configuration\ConfigWriter class which doesn't exist. This
+ * class is a stub to prevent BC Break change.
+ *
+ * @deprecated Use Laminas\Config\Writer\PhpArray
+ *  or Laminas\Config\Writer\WriterInterface instead.
+ */
+class ConfigWriter extends PhpArray
+{
+}

--- a/test/ConfigResourceFactoryTest.php
+++ b/test/ConfigResourceFactoryTest.php
@@ -4,6 +4,7 @@ namespace LaminasTest\ApiTools\Configuration;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ApiTools\Configuration\ConfigResource;
+use Laminas\ApiTools\Configuration\ConfigWriter;
 use Laminas\ApiTools\Configuration\Factory\ConfigResourceFactory;
 use Laminas\Config\Writer\WriterInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -14,7 +15,7 @@ use function uniqid;
 class ConfigResourceFactoryTest extends TestCase
 {
     /** @var string */
-    private const WRITER_SERVICE = 'Laminas\ApiTools\Configuration\ConfigWriter';
+    private const WRITER_SERVICE = ConfigWriter::class;
 
     /**
      * @var ContainerInterface|MockObject


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR is a replacement for #20.
It fixes two things:
* Fixed missing yet referred ConfigWriter class
* Fixed ConfigResourceFactory used in SM config instead of Resource Factory

In the previous PR #20 wrong branch was used, also the fix for ConfigWriter there would introduce a BC Break. Here I used a different approach and just created a missing class and deprecated it right away, so other modules relying on it should work, yet they will be advised to switch to WriterInterface or PhpArray instead.

This PR should also fix #5